### PR TITLE
Bugfix/cpp usage and other fixes

### DIFF
--- a/libraries/ota-for-aws-iot-embedded-sdk/port/aws_esp_ota_ops.c
+++ b/libraries/ota-for-aws-iot-embedded-sdk/port/aws_esp_ota_ops.c
@@ -24,6 +24,7 @@
 
 #include "esp_err.h"
 #include "esp_partition.h"
+#include "esp_idf_version.h"
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
     #include "spi_flash_mmap.h"    
 #else

--- a/libraries/ota-for-aws-iot-embedded-sdk/port/ota_os_freertos.h
+++ b/libraries/ota-for-aws-iot-embedded-sdk/port/ota_os_freertos.h
@@ -36,6 +36,10 @@
 /* OTA library interface include. */
 #include "ota_os_interface.h"
 
+#if defined(__cplusplus)
+extern "C" {
+#endif // defined(__cplusplus)
+
 /**
  * @brief Initialize the OTA events.
  *
@@ -162,5 +166,9 @@ void * Malloc_FreeRTOS( size_t size );
  */
 
 void Free_FreeRTOS( void * ptr );
+
+#if defined(__cplusplus)
+}
+#endif // defined(__cplusplus)
 
 #endif /* ifndef _OTA_OS_FREERTOS_H_ */

--- a/libraries/ota-for-aws-iot-embedded-sdk/port/ota_pal.c
+++ b/libraries/ota-for-aws-iot-embedded-sdk/port/ota_pal.c
@@ -164,7 +164,7 @@ static void _esp_ota_ctx_clear( esp_ota_context_t * ota_ctx )
 
 static bool _esp_ota_ctx_validate( OtaFileContext_t * pFileContext )
 {
-    return( pFileContext != NULL && ota_ctx.cur_ota == pFileContext && pFileContext->pFile == ( uint8_t * ) &ota_ctx );
+    return( (pFileContext != NULL) && (ota_ctx.cur_ota == pFileContext) && ((uint8_t *)pFileContext->pFile == ( uint8_t * ) &ota_ctx) );
 }
 
 static void _esp_ota_ctx_close( OtaFileContext_t * pFileContext )

--- a/libraries/ota-for-aws-iot-embedded-sdk/port/ota_pal.c
+++ b/libraries/ota-for-aws-iot-embedded-sdk/port/ota_pal.c
@@ -35,7 +35,7 @@
 #include "hal/wdt_hal.h"
 
 #include "esp_partition.h"
-
+#include "esp_idf_version.h"
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
     #include "spi_flash_mmap.h"    
 #else

--- a/libraries/ota-for-aws-iot-embedded-sdk/port/ota_pal.h
+++ b/libraries/ota-for-aws-iot-embedded-sdk/port/ota_pal.h
@@ -34,6 +34,9 @@
 #include "ota.h"
 #include "esp_err.h"
 
+#if defined(__cplusplus)
+extern "C" {
+#endif // defined(__cplusplus)
 /**
  * @brief Abort an OTA transfer.
  *
@@ -227,5 +230,9 @@ esp_err_t otaPal_EraseLastBootPartition(void);
  *        - true:    If successful.
  */
 bool otaPal_SetCodeSigningCertificate(const char * pcCodeSigningCertificatePEM);
+
+#if defined(__cplusplus)
+}
+#endif // defined(__cplusplus)
 
 #endif /* ifndef OTA_PAL_H_ */


### PR DESCRIPTION
These are the minimal changes performed to work with my project.

There are many other changes that could be added to clean-up the code Items that were found are documented in this CMakeLists.txt file:

I build with the following global settings and using Clang-14 and GNU-11 on Ubuntu 22.04.

I am not using the `ESP-IDF` provided CMakeLists.txt as they do not function well with my own native CMake environment and content with items because the `esp-idf` is using CMake in an unconventional means.

Project level compile options:
```cmake
add_compile_options(
    $<$<COMPILE_LANG_AND_ID:C,GNU>:-fdiagnostics-color=always>
    $<$<COMPILE_LANG_AND_ID:C,Clang>:-fcolor-diagnostics>

    $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wall>
    $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wextra>
    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wpedantic> # Note not used in GNU to allow C99 designated initializers.
    $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Werror>
    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Weverything>

    # Documentation types
    $<$<COMPILE_LANG_AND_ID:C,Clang>:-fcomment-block-commands=retval> # Doesn't recongize doxygen retval
    $<$<COMPILE_LANG_AND_ID:C,Clang>:-fcomment-block-commands=copydetails> # Doesn't recongize doxygen copydetails
    $<$<COMPILE_LANG_AND_ID:C,Clang>:-fcomment-block-commands=startuml> # Doesn't recongize doxygen + plantuml staruml
    $<$<COMPILE_LANG_AND_ID:C,Clang>:-fcomment-block-commands=enduml> # Doesn't recongize doxygen + plantuml staruml
)
```

You can ignore the:
* target_ignore_static_analysis() calls in the cmake file below - these are to disable Clang Tidy and other static analysis tools.

CMakeLists.txt file copied into the root of this directory:
[esp_aws_iot.cmake.txt](https://github.com/Retlek-Systems-Inc/esp-aws-iot/files/10241739/esp_aws_iot.cmake.txt)

It would be appreciated if cleanup of the various compile warnings inside the above cmake file were cleaned up in the code to ensure that assumption/expectation is correct.